### PR TITLE
ruby: fix running tests

### DIFF
--- a/modules/RockRuby.cmake
+++ b/modules/RockRuby.cmake
@@ -238,9 +238,13 @@ else()
             endif()
         endforeach()
 
+        foreach(test_file ${testfiles})
+            set(test_requires "${test_requires}require '${test_file}';")
+        endforeach()
+
         add_test(NAME test-${TARGET}-ruby
             WORKING_DIRECTORY "${workdir}"
-            COMMAND ${RUBY_EXECUTABLE} -rminitest/autorun -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_BINARY_DIR} ${testfiles})
+            COMMAND ${RUBY_EXECUTABLE} -rminitest/autorun -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_BINARY_DIR} -e "${test_requires}")
     endfunction()
 endif()
 


### PR DESCRIPTION
The tests under minitest must be require'd, not simply passed
as command-line parameters. We were currently only running the
first test file.
