### PR TITLE
fixed wrong variable name in rock_add_plain_dependency

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -207,7 +207,7 @@ macro (rock_add_plain_dependency VARIABLE)
     # Normalize plural/singular
     foreach(__varname INCLUDE_DIR LIBRARY_DIR)
         if (NOT ${VARIABLE}_${__varname}S)
-            set(${VARIABLE}_${__varname}S "${${VARNAME}_${__varname}}")
+            set(${VARIABLE}_${__varname}S "${${VARIABLE}_${__varname}}")
         endif()
     endforeach()
 


### PR DESCRIPTION
Please pull this fix soon, this bug leads to build fails with graph_slam and most probably other packages.
