### PR TITLE
add dependency on pkg-config

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,5 +10,6 @@
     </copyright>
     <license>LGPL v2 or later</license>
     <depend package="cmake" />
+    <depend package="pkg-config" />
     <tags>stable</tags>
 </package>


### PR DESCRIPTION
While pkg-config is not strictly a dependency of base/cmake, Rock pushes for the use of pkg-config (i.e. most, if not all, packages that use the Rock cmake macros will use pkg-config). This is the closest thing that would allow us to properly install pkg-config, short of hardcoding it into autoproj.