### PR TITLE
Turn C++11 on by default

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -56,6 +56,9 @@ macro (rock_init PROJECT_NAME PROJECT_VERSION)
     rock_use_full_rpath("${CMAKE_INSTALL_PREFIX}/lib")
     include(CheckCXXCompilerFlag)
     include(FindPkgConfig)
+    
+    OPTION(ROCK_USE_CXX11 "Compile package using the C++11 standard" ON)
+
     if(ROCK_USE_CXX11)
         rock_activate_cxx11()
     endif()


### PR DESCRIPTION
This commit turns on c++11 by default.
It still may be turned off by setting 
ROCK_USE_CXX11 to false.
