### PR TITLE
rock_testsuite: optionally generate boost XML output reports in test/<testsuite_name>.boost.xml

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -739,8 +739,19 @@ function(rock_testsuite TARGET_NAME)
     rock_executable(${TARGET_NAME} ${ARGN}
         NOINSTALL)
     target_link_libraries(${TARGET_NAME} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+    if (ROCK_TEST_LOG_DIR)
+        list(APPEND __boost_test_parameters
+            --log_format=xml
+            --log_level=all
+            --log_sink=${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.boost.xml)
+        file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")
+    endif()
+
+
     add_test(NAME test-${TARGET_NAME}-cxx
-        COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME})
+        COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME}
+        ${__boost_test_parameters})
 endfunction()
 
 macro(rock_libraries_for_pkgconfig VARNAME)


### PR DESCRIPTION
This allows to integrate with common test report systems. Set ROCK_TEST_LOG_DIR to activate.

Set up by https://github.com/rock-core/package_set/pull/97