### PR TITLE
Add google-mock and gtest support

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -209,7 +209,7 @@ macro(rock_standard_layout)
     endif()
 
     if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
-        option(ROCK_TEST_ENABLED "set to OFF to disable the unit tests. Tests are automatically disabled if the boost unit test framework is not available" ON)
+        option(ROCK_TEST_ENABLED "set to ON to enable the unit tests" OFF)
         if (ROCK_TEST_ENABLED)
             add_subdirectory(test)
         else()

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -761,7 +761,7 @@ endfunction()
 function(rock_testsuite TARGET_NAME)
     rock_test_common(${TARGET_NAME} ${ARGN})
     rock_setup_boost_test(${TARGET_NAME})
-    rock_add_test(${TARGET_NAME})
+    rock_add_test(${TARGET_NAME} "${__rock_test_parameters}")
 endfunction()
 
 ## Uses gtest + google-mock as unit testing framework
@@ -793,10 +793,10 @@ function(rock_gtest TARGET_NAME)
                                     ${ARGN})
 
     rock_setup_gtest_test(${TARGET_NAME} ${GMOCK_DIR} ${GTEST_DIR})
-    rock_add_test(${TARGET_NAME})
+    rock_add_test(${TARGET_NAME} "${__rock_test_parameters}")
 endfunction()
 
-macro(rock_setup_gtest_test TARGET_NAME GMOCK_DIR GTEST_DIR)
+function(rock_setup_gtest_test TARGET_NAME GMOCK_DIR GTEST_DIR)
     target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${GMOCK_DIR} ${GTEST_DIR}
                                ${GMOCK_DIR}/include ${GTEST_DIR}/include)
     target_link_libraries(${TARGET_NAME} pthread)
@@ -805,8 +805,9 @@ macro(rock_setup_gtest_test TARGET_NAME GMOCK_DIR GTEST_DIR)
         list(APPEND __rock_test_parameters
              --gtest_output=xml:${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.gtest.xml)
         file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")
+        set(__rock_test_parameters ${__rock_test_parameters} PARENT_SCOPE)
     endif()
-endmacro()
+endfunction()
 
 function(rock_test_common TARGET_NAME)
     if (TARGET_NAME STREQUAL "test")
@@ -817,7 +818,7 @@ function(rock_test_common TARGET_NAME)
     rock_executable(${TARGET_NAME} ${ARGN} NOINSTALL)
 endfunction()
 
-macro(rock_setup_boost_test TARGET_NAME)
+function(rock_setup_boost_test TARGET_NAME)
     find_package(Boost REQUIRED COMPONENTS unit_test_framework system)
     message(STATUS "boost/test found ... building the test suite")
 
@@ -830,14 +831,15 @@ macro(rock_setup_boost_test TARGET_NAME)
              --log_level=all
              --log_sink=${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.boost.xml)
         file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")
+        set(__rock_test_parameters ${__rock_test_parameters} PARENT_SCOPE)
     endif()
-endmacro()
+endfunction()
 
-macro(rock_add_test TARGET_NAME)
+function(rock_add_test TARGET_NAME __rock_test_parameters)
     add_test(NAME test-${TARGET_NAME}-cxx
              COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME}
              ${__rock_test_parameters})
-endmacro()
+endfunction()
 
 ## Get the library name from a given path
 #

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -211,13 +211,7 @@ macro(rock_standard_layout)
     if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/test)
         option(ROCK_TEST_ENABLED "set to OFF to disable the unit tests. Tests are automatically disabled if the boost unit test framework is not available" ON)
         if (ROCK_TEST_ENABLED)
-            find_package(Boost COMPONENTS unit_test_framework system)
-            if (Boost_UNIT_TEST_FRAMEWORK_FOUND)
-                message(STATUS "boost/test found ... building the test suite")
-                add_subdirectory(test)
-            else()
-                message(STATUS "boost/test not found ... NOT building the test suite")
-            endif()
+            add_subdirectory(test)
         else()
             message(STATUS "unit tests disabled as ROCK_TEST_ENABLED is set to OFF")
         endif()
@@ -765,28 +759,85 @@ endfunction()
 # files, they get added to the library and the corresponding header file is
 # passed to moc.
 function(rock_testsuite TARGET_NAME)
+    rock_test_common(${TARGET_NAME} ${ARGN})
+    rock_setup_boost_test()
+    rock_add_test()
+endfunction()
+
+## Uses gtest + google-mock as unit testing framework
+# The interface is the same as the one from rock_testsuite
+#
+# Unfortunately, gtest and google-mock do not ship with
+# pre-compiled libraries so we have to add their source files
+# to the test target. If GTEST_DIR or GMOCK_DIR are not set,
+# this function will look for the required source files
+# in /usr/src, which is the default path under ubuntu/debian
+function(rock_gtest TARGET_NAME)
+    if (NOT GTEST_DIR)
+        find_path(GTEST_DIR "src/gtest-all.cc" /usr/src/gtest)
+    endif()
+    if (NOT GMOCK_DIR)
+        find_path(GMOCK_DIR "src/gmock-all.cc" /usr/src/gmock)
+    endif()
+
+    if (NOT GTEST_DIR)
+        message(FATAL_ERROR "Could not find gtest in /usr/src")
+    endif()
+    if (NOT GMOCK_DIR)
+        message(FATAL_ERROR "Could not find google-mock in /usr/src")
+    endif()
+    message(STATUS "gtest found ... building the test suite")
+
+    rock_test_common(${TARGET_NAME} ${GTEST_DIR}/src/gtest-all.cc
+                                    ${GMOCK_DIR}/src/gmock-all.cc
+                                    ${ARGN})
+
+    rock_setup_gtest_test()
+    rock_add_test()
+endfunction()
+
+macro(rock_setup_gtest_test)
+    target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${GMOCK_DIR} ${GTEST_DIR}
+                               ${GMOCK_DIR}/include ${GTEST_DIR}/include)
+    target_link_libraries(${TARGET_NAME} pthread)
+
+    if (ROCK_TEST_LOG_DIR)
+        list(APPEND __rock_test_parameters
+             --gtest_output=xml:${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.gtest.xml)
+        file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")
+    endif()
+endmacro()
+
+function(rock_test_common TARGET_NAME)
     if (TARGET_NAME STREQUAL "test")
         message(WARNING "test name cannot be 'test', renaming to '${PROJECT_NAME}-test'")
         set(TARGET_NAME "${PROJECT_NAME}-test")
     endif()
+
+    rock_executable(${TARGET_NAME} ${ARGN} NOINSTALL)
+endfunction()
+
+macro(rock_setup_boost_test)
+    find_package(Boost REQUIRED COMPONENTS unit_test_framework system)
+    message(STATUS "boost/test found ... building the test suite")
+
     add_definitions(-DBOOST_TEST_DYN_LINK)
-    rock_executable(${TARGET_NAME} ${ARGN}
-        NOINSTALL)
     target_link_libraries(${TARGET_NAME} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
     if (ROCK_TEST_LOG_DIR)
-        list(APPEND __boost_test_parameters
-            --log_format=xml
-            --log_level=all
-            --log_sink=${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.boost.xml)
+        list(APPEND __rock_test_parameters
+             --log_format=xml
+             --log_level=all
+             --log_sink=${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.boost.xml)
         file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")
     endif()
+endmacro()
 
-
+macro(rock_add_test)
     add_test(NAME test-${TARGET_NAME}-cxx
-        COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME}
-        ${__boost_test_parameters})
-endfunction()
+             COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME}
+             ${__rock_test_parameters})
+endmacro()
 
 ## Get the library name from a given path
 #

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -760,8 +760,8 @@ endfunction()
 # passed to moc.
 function(rock_testsuite TARGET_NAME)
     rock_test_common(${TARGET_NAME} ${ARGN})
-    rock_setup_boost_test()
-    rock_add_test()
+    rock_setup_boost_test(${TARGET_NAME})
+    rock_add_test(${TARGET_NAME})
 endfunction()
 
 ## Uses gtest + google-mock as unit testing framework
@@ -792,11 +792,11 @@ function(rock_gtest TARGET_NAME)
                                     ${GMOCK_DIR}/src/gmock-all.cc
                                     ${ARGN})
 
-    rock_setup_gtest_test()
-    rock_add_test()
+    rock_setup_gtest_test(${TARGET_NAME} ${GMOCK_DIR} ${GTEST_DIR})
+    rock_add_test(${TARGET_NAME})
 endfunction()
 
-macro(rock_setup_gtest_test)
+macro(rock_setup_gtest_test TARGET_NAME GMOCK_DIR GTEST_DIR)
     target_include_directories(${TARGET_NAME} SYSTEM PUBLIC ${GMOCK_DIR} ${GTEST_DIR}
                                ${GMOCK_DIR}/include ${GTEST_DIR}/include)
     target_link_libraries(${TARGET_NAME} pthread)
@@ -817,7 +817,7 @@ function(rock_test_common TARGET_NAME)
     rock_executable(${TARGET_NAME} ${ARGN} NOINSTALL)
 endfunction()
 
-macro(rock_setup_boost_test)
+macro(rock_setup_boost_test TARGET_NAME)
     find_package(Boost REQUIRED COMPONENTS unit_test_framework system)
     message(STATUS "boost/test found ... building the test suite")
 
@@ -833,7 +833,7 @@ macro(rock_setup_boost_test)
     endif()
 endmacro()
 
-macro(rock_add_test)
+macro(rock_add_test TARGET_NAME)
     add_test(NAME test-${TARGET_NAME}-cxx
              COMMAND ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME}
              ${__rock_test_parameters})


### PR DESCRIPTION
This adds support for google-test + google-mock as unit testing framework. Additionally, CMake won't silently ignore unmet dependency anymore. If ROCK_TEST_ENABLED flag is set and the required package is not found, build will fail.