### PR TITLE
make finding the gem executable more robust

### DIFF
--- a/modules/FindGem.cmake
+++ b/modules/FindGem.cmake
@@ -27,8 +27,8 @@
 #
 # Check for how 'gem' should be called
 include(FindPackageHandleStandardArgs)
-find_program(GEM_EXECUTABLE
-    NAMES "gem${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
+
+list(APPEND __gem_names "gem${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
         "gem${RUBY_VERSION_MAJOR}.${RUBY_VERSION_MINOR}"
         "gem-${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}"
         "gem-${RUBY_VERSION_MAJOR}.${RUBY_VERSION_MINOR}"
@@ -37,6 +37,14 @@ find_program(GEM_EXECUTABLE
         "gem-${RUBY_VERSION_MAJOR}${RUBY_VERSION_MINOR}${RUBY_VERSION_PATCH}"
         "gem-${RUBY_VERSION_MAJOR}.${RUBY_VERSION_MINOR}.${RUBY_VERSION_PATCH}"
         "gem")
+
+if (RUBY_EXECUTABLE)
+    get_filename_component(__ruby_dir "${RUBY_EXECUTABLE}" DIRECTORY)
+    find_program(GEM_EXECUTABLE
+        NAMES ${__gem_names}
+        PATHS "${__ruby_dir}" NO_DEFAULT_PATH)
+endif()
+find_program(GEM_EXECUTABLE NAMES ${__gem_names})
 
 # Making backward compatible
 if(Gem_DEBUG)


### PR DESCRIPTION
The current scheme (using minor.major works well for Ubuntu-based systems
and system-installed ruby versions. However, it fails in case one is
using a ruby version manager (rbenv in my case) and have versions that
only differ by the minor part (2.3.1 vs 2.3.4).

If RUBY_EXECUTABLE is explicitly provided, look first in the same
directory than the ruby executable, and only afterwards fallback
to a full search. This takes the rbenv/rvm case into account without
changing the current behaviour.