### PR TITLE
Disable CMAKE_CXX_EXTENSIONS which are ON by default

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -29,6 +29,7 @@
 #   set(ROCK_PUBLIC_CXX_STANDARD)
 #
 macro(rock_activate_cxx11)
+    set(CMAKE_CXX_EXTENSIONS OFF)
     set(CMAKE_CXX_STANDARD 11)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
This intends to avoid a conflicting propagation of compiler specific cxx standard flags while,
e.g. c++11 is exported to the pkgconfig file.