### PR TITLE
enable compilation database in rock projects

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -120,7 +120,7 @@ macro (rock_init PROJECT_NAME PROJECT_VERSION)
     rock_add_compiler_flag_if_it_exists(-Wall)
     rock_add_compiler_flag_if_it_exists(-Wno-unused-local-typedefs)
     add_definitions(-DBASE_LOG_NAMESPACE=${PROJECT_NAME})
-
+    add_definitions(-DCMAKE_EXPORT_COMPILE_COMMANDS=ON)
     if (ROCK_TEST_ENABLED)
         enable_testing()
     endif()


### PR DESCRIPTION
If enabled, cmake generates a compile_commands.json file containing the exact compiler calls for all translation units of the project in machine-readable form. This is useful for automated build systems/tools.

References: 
- [1] https://cmake.org/cmake/help/v3.5/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
- [2] http://clang.llvm.org/docs/JSONCompilationDatabase.html