### PR TITLE
Boost Test does not accept lowercase format anymore

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -892,7 +892,7 @@ function(rock_setup_boost_test TARGET_NAME)
 
     if (ROCK_TEST_LOG_DIR)
         list(APPEND __rock_test_parameters
-             --log_format=xml
+             --log_format=XML
              --log_level=all
              --log_sink=${ROCK_TEST_LOG_DIR}/${TARGET_NAME}.boost.xml)
         file(MAKE_DIRECTORY "${ROCK_TEST_LOG_DIR}")


### PR DESCRIPTION
Fix for Ubuntu 18.04 with boost version 1.65
Previous version included in Ubuntu 16.04 are case insensitive