### PR TITLE
Use CMAKE_PREFIX_PATH instead of CMAKE_INSTALL_PREFIX:

### DIFF
--- a/modules/FindSISL.cmake
+++ b/modules/FindSISL.cmake
@@ -1,14 +1,14 @@
 set(SISL_FOUND FALSE)
 
 if (NOT SISL_PREFIX)
-    set(SISL_PREFIX ${CMAKE_INSTALL_PREFIX} CACHE FILEPATH "the installation prefix for the SISL library")
+    set(SISL_PREFIX ${CMAKE_PREFIX_PATH} CACHE FILEPATH "the installation prefix for the SISL library")
 endif()
 
 find_path(SISL_INCLUDE_DIRS "sisl.h"
-    HINTS ${SISL_PREFIX}/include ${CMAKE_INSTALL_PREFIX}/include)
+    HINTS ${SISL_PREFIX}/include ${CMAKE_PREFIX_PATH}/include)
 find_library(SISL_LIBRARIES
     NAMES libsisl${CMAKE_SHARED_LIBRARY_SUFFIX} libsisl_opt${CMAKE_SHARED_LIBRARY_SUFFIX} libsisl.a libsisl_opt.a
-    HINTS ${SISL_PREFIX}/lib ${CMAKE_INSTALL_PREFIX}/lib)
+    HINTS ${SISL_PREFIX}/lib ${CMAKE_PREFIX_PATH}/lib)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(SISL "SISL library not found, NURBS 3D curve wrappers won't be installed" SISL_INCLUDE_DIRS SISL_LIBRARIES)


### PR DESCRIPTION
- The previous CMake assumes that there is only one installation folder but when using the Rock osdeps there are two: One for the debian packages and one for the code compiled on the machine.