### PR TITLE
ruby: export a junit report in Ruby test targets if ROCK_TEST_LOG_DIR is set

### DIFF
--- a/modules/RockRuby.cmake
+++ b/modules/RockRuby.cmake
@@ -107,6 +107,7 @@ function(rock_add_ruby_package NAME)
         rock_ruby_library(${NAME} ${pure_ruby_files})
 
         if (ROCK_TEST_ENABLED AND IS_DIRECTORY test)
+            enable_testing()
             rock_ruby_test(${NAME})
         endif()
 
@@ -211,6 +212,12 @@ else()
     # source directory.
     #
     # The default working directory is the current source directory.
+    #
+    # If the ROCK_TEST_LOG_DIR CMake variable is set, a test report will be
+    # generated under that directory with the name `${TARGET}.junit.xml`. This
+    # support is dependent on the availability of the `minitest-jruby` plugin.
+    # The rock.core package set auto-adds this dependency for CMake packages
+    # that have Rock's `bindings/ruby/test` standard directory
     function(ROCK_RUBY_TEST TARGET)
         set(workdir ${CMAKE_CURRENT_SOURCE_DIR})
         set(mode FILES)
@@ -251,9 +258,22 @@ else()
             set(test_requires "${test_requires}require '${test_file}';")
         endforeach()
 
+        if (ROCK_TEST_LOG_DIR)
+            file(MAKE_DIRECTORY ${ROCK_TEST_LOG_DIR})
+            list(APPEND __minitest_args
+                --junit
+                --junit-filename=${ROCK_TEST_LOG_DIR}/${TARGET}.junit.xml
+                --junit-jenkins
+            )
+        endif()
+
         add_test(NAME test-${TARGET}-ruby
             WORKING_DIRECTORY "${workdir}"
-            COMMAND ${RUBY_EXECUTABLE} -rminitest/autorun -I${CMAKE_CURRENT_SOURCE_DIR}/lib -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_BINARY_DIR} -e "${test_requires}")
+            COMMAND ${RUBY_EXECUTABLE} -rminitest/autorun -I${CMAKE_CURRENT_SOURCE_DIR}/lib 
+                    -I${CMAKE_CURRENT_SOURCE_DIR} -I${CMAKE_CURRENT_BINARY_DIR} -e "${test_requires}"
+                    --
+                    ${__minitest_args}
+        )
     endfunction()
 endif()
 


### PR DESCRIPTION
This is already what rock.core does for Ruby packages.

