### PR TITLE
fix rock_init's misfeature of trying to call project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.0)
+project(cmake VERSION 1.0 DESCRIPTION "Rock's core CMake macros")
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 include(${CMAKE_CURRENT_SOURCE_DIR}/modules/Rock.cmake)
-rock_init(cmake 1.0)
+rock_init()
 
 install(FILES
     modules/FindBoost.cmake

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -108,9 +108,17 @@ endfunction()
 
 
 ## Main initialization for Rock CMake projects
-macro (rock_init PROJECT_NAME PROJECT_VERSION)
-    project(${PROJECT_NAME})
-    set(PROJECT_VERSION ${PROJECT_VERSION})
+macro (rock_init)
+    if (${ARGC} GREATER 0)
+        message(WARNING "Passing project name and version to rock_init was a misfeature \
+of Rock's macros since CMake 3.0. You must call CMake's project() \
+at toplevel, like this:\
+\nproject(${ARGV0} VERSION ${ARGV1} DESCRIPTION \"project description\")\
+\nRemove the arguments to rock_init() to silence this warning")
+        project(${ARGV0})
+        set(PROJECT_VERSION ${ARGV1})
+    endif()
+
     rock_use_full_rpath("${CMAKE_INSTALL_PREFIX}/lib")
     include(CheckCXXCompilerFlag)
     include(FindPkgConfig)


### PR DESCRIPTION
Ever since CMake 3.0, project() must be called *literally* at
toplevel. Newer version of CMake (in my case 3.16) finally
started to warn about it, but the documentation is clear.

https://cmake.org/cmake/help/v3.0/command/project.html

I'm still calling `project()` in case it does something (maybe
set the version ?)