### PR TITLE
make it compatible with cmake higher than 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-project(cmake VERSION 1.0 DESCRIPTION "Rock's core CMake macros")
+project(cmake VERSION 1.0)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/modules")
 include(${CMAKE_CURRENT_SOURCE_DIR}/modules/Rock.cmake)
 rock_init()


### PR DESCRIPTION
the DESCRIPTION option was only added on version 3.9
removing it allows compatibility with cmake 3.5.1, which
is native for ubuntu 16.04