### PR TITLE
Improve qt5

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -1407,11 +1407,13 @@ macro (rock_find_qt5)
     endif()
 
     find_package(Qt5 ${__arg_optreq} COMPONENTS Core Gui Widgets OpenGL ${__arglist})
-    set(ROCK_QT_VERSION 5)
+    if(Qt5_FOUND)
+        set(CMAKE_AUTOMOC ON)
+        set(CMAKE_AUTORCC ON)
+        set(CMAKE_AUTOUIC ON)
 
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_AUTORCC ON)
-    set(CMAKE_AUTOUIC ON)
+        set(ROCK_QT_VERSION 5)
+    endif()
 endmacro()
 
 # Autodetect the available OpenCV version and make it available for Rock's DEPS_PKGCONFIG mechanism

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -1406,7 +1406,7 @@ macro (rock_find_qt5)
         set(__arg_optreq REQUIRED)
     endif()
 
-    find_package(Qt5 ${__arg_optreq} COMPONENTS ${__arglist})
+    find_package(Qt5 ${__arg_optreq} COMPONENTS Core Gui Widgets OpenGL ${__arglist})
     set(ROCK_QT_VERSION 5)
 
     set(CMAKE_AUTOMOC ON)

--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -1391,11 +1391,17 @@ endmacro()
 #
 # The macro finds QtCore, QtGui and QtOpenGL by default. Additional arguments
 # can be given to find more components.
+#
+# The argument list can also contain OPTIONAL or REQUIRED, default is to
+# assume REQUIRED.
 macro (rock_find_qt5)
     set(__arglist "${ARGN}")
-    list(GET 0 __arglist __arg_optreq)
-    if ((__arg_optreq EQUAL "OPTIONAL") OR (__arg_optreq EQUAL "REQUIRED"))
-        list(REMOVE_AT __arglist 0)
+    list(FIND __arglist OPTIONAL __arg_optional)
+    list(FIND __arglist REQUIRED __arg_requried)
+    list(REMOVE_ITEM __arglist OPTIONAL)
+    list(REMOVE_ITEM __arglist REQUIRED)
+    if (__arg_optional GREATER -1)
+        set(__arg_optreq )
     else()
         set(__arg_optreq REQUIRED)
     endif()


### PR DESCRIPTION
No effect on packages expected.

This relaxes the argument ordering requirement for rock_find_qt5.
