### PR TITLE
Remove setting of CMAKE_AUTO{MOC,RCC,UIC} from rock_find_qt5

### DIFF
--- a/modules/Rock.cmake
+++ b/modules/Rock.cmake
@@ -1402,10 +1402,6 @@ macro (rock_find_qt5)
 
     find_package(Qt5 ${__arg_optreq} COMPONENTS ${__arglist})
     set(ROCK_QT_VERSION 5)
-
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_AUTORCC ON)
-    set(CMAKE_AUTOUIC ON)
 endmacro()
 
 # Autodetect the available OpenCV version and make it available for Rock's DEPS_PKGCONFIG mechanism


### PR DESCRIPTION
While these are somewhat nice to have, they are also current directory settings that are better left to the user of the rock macros, and equally affect Qt4 and Qt5. These do not mix with MOC/UI elements of rock_library etc. at all. Where needed, I will adjust the feature/qt5 branches, so they declare their own CMAKE_AUTO{MOC,RCC,UIC}.